### PR TITLE
Added docker inference only server

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,15 @@ print("Answer:", answer)
 ```
 For more information on our clients visit: [Python](https://pypi.org/project/moondream/), [Node](https://www.npmjs.com/package/moondream), [Quick Start](https://moondream.ai/c/docs/quickstart)
 
+### Docker Inference only Server
+To run an inference only server in a docker container. The following command builds and runs the inference only docker container:
+```
+make inference-server
+```
+
+Make sure you have the build dependencies installed before running the command (make).
+*(Note: on ubuntu, you can install make with `sudo apt install build-essential`)*
+
 ## Administrative Commands
 
 Access administrative functions using the `admin` command:

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ For more information on our clients visit: [Python](https://pypi.org/project/moo
 ### Docker Inference only Server
 To run an inference only server in a docker container. The following command builds and runs the inference only docker container:
 ```
+cd app/
 make inference-server
 ```
 

--- a/app/Makefile
+++ b/app/Makefile
@@ -1,0 +1,21 @@
+.PHONY: inference-server
+inference-server: docker-build-inference-server docker-run-inference-server
+
+.PHONY: docker-build-inference-server
+docker-build-inference-server:
+	@docker build -t moondream-station-inference:latest -f dockerfile.inference .
+
+.PHONY: docker-run-inference-server
+docker-run-inference-server:
+	@docker run -p 20200:20200 moondream-station-inference:latest
+
+.PHONY: docker-setup
+docker-setup:
+	@chmod +x setup_docker.sh && \
+	./setup_docker.sh
+
+.PHONY: modal_setup
+modal_setup:
+	@chmod +x modal_setup.sh && \
+	./modal_setup.sh
+

--- a/app/docker_inference_server_build.sh
+++ b/app/docker_inference_server_build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+docker build -t moondream-station-inference:latest -f dockerfile.inference .

--- a/app/docker_inference_server_build.sh
+++ b/app/docker_inference_server_build.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -e
-
-docker build -t moondream-station-inference:latest -f dockerfile.inference .

--- a/app/dockerfile.inference
+++ b/app/dockerfile.inference
@@ -30,9 +30,7 @@ RUN ln -sf /usr/local/bin/pip3.10 /usr/bin/pip
 WORKDIR /app
 RUN pip install pyinstaller distro certifi
 
-
-COPY build.sh /app/build.sh
-COPY ./inference_client /app/moondream-station/app/inference_client
+COPY . /app/moondream-station/app
 WORKDIR /app/moondream-station/app/
 
 RUN chmod +x build.sh

--- a/app/dockerfile.inference
+++ b/app/dockerfile.inference
@@ -1,0 +1,46 @@
+FROM ubuntu:24.04
+
+
+WORKDIR /tmp
+RUN apt update && apt install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev libsqlite3-dev wget libbz2-dev git
+RUN wget https://www.python.org/ftp/python/3.10.12/Python-3.10.12.tgz
+RUN tar -xf Python-3.10.12.tgz
+
+WORKDIR /tmp/Python-3.10.12
+
+RUN ./configure --enable-shared --enable-optimizations --prefix=/usr/local
+RUN make -j 10
+RUN make altinstall
+
+RUN echo '/usr/local/lib' > /etc/ld.so.conf.d/python310.conf
+RUN ldconfig
+
+RUN ln -sf /usr/local/bin/python3.10 /usr/bin/python3.10
+RUN ln -sf /usr/local/bin/python3.10 /usr/bin/python3
+RUN rm -f /usr/bin/python
+RUN ln -sf /usr/local/bin/python3.10 /usr/bin/python
+
+RUN export PATH=/usr/local/bin:\$PATH
+RUN echo 'export PATH=/usr/local/bin:\$PATH' >> ~/.bashrc
+
+RUN /usr/local/bin/python3.10 -m ensurepip
+RUN ln -sf /usr/local/bin/pip3.10 /usr/bin/pip3
+RUN ln -sf /usr/local/bin/pip3.10 /usr/bin/pip
+
+WORKDIR /app
+RUN pip install pyinstaller distro certifi
+
+
+COPY build.sh /app/build.sh
+COPY ./inference_client /app/moondream-station/app/inference_client
+WORKDIR /app/moondream-station/app/
+
+RUN chmod +x build.sh
+RUN ./build.sh dev ubuntu --build-clean --inference=2025-06-21
+
+WORKDIR /app/moondream-station/app/inference_client
+
+RUN pip install -r requirements.txt
+EXPOSE 20200:20200
+
+CMD ["python3", "/app/moondream-station/app/inference_client/main.py", "--revision=2025-06-21"]

--- a/app/hypervisor/data/manifest.json
+++ b/app/hypervisor/data/manifest.json
@@ -15,6 +15,20 @@
     },
     "models": {
         "2b": {
+            "2b": {
+                "Moondream2-2025-06-21": {
+                    "release_date": "2025-06-21",
+                    "model_id": "vikhyatk/moondream2",
+                    "revision": "2025-06-21",
+                    "notes": "Our latest Float16 Moondream",
+                    "model_size": "1.93B",
+                    "dtype": "fp16",
+                    "support_osx": true,
+                    "support_ubuntu": true,
+                    "support_windows": false,
+                    "inference_client": "v0.0.1"
+                }
+            },
             "Moondream2-INT4": {
                 "release_date": "2025-05-21",
                 "model_id": "moondream/moondream-2b-2025-04-14-4bit",

--- a/app/inference_client/model_service.py
+++ b/app/inference_client/model_service.py
@@ -13,10 +13,10 @@ class ModelService:
         self.device = self._get_best_device()
         logger.info(f"Initializing model on device: {self.device}")
         self.tokenizer = AutoTokenizer.from_pretrained(
-            model_name, revision=None, trust_remote_code=True
+            model_name, revision=revision, trust_remote_code=True
         )
         self.model = AutoModelForCausalLM.from_pretrained(
-            model_name, revision=None, trust_remote_code=True
+            model_name, revision=revision, trust_remote_code=True
         )
         self.model.to(self.device)
         logger.info(f"Model commit hash: {self.model.config._commit_hash}")


### PR DESCRIPTION
Hi @m87-labs,

added a small convenience inference only docker file and build script:

- added new `Makefile` to `/app`
- added new docker file for building inference only server
- tested locally and working
- fixed `revision not passed` in init in inference_client /model_service.py

Please feel free to just refuse this pull request, I don't know if this aligns with your vision!

If you want any updates to this PR before considering a merge, LMK. 
Love the repo :)