### PR TITLE
Added Dockerfile for moondream station

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,21 @@
+# Docker ignore file
+__pycache__
+*.py[cod]
+*.pyo
+*.pyd
+.Python
+venv
+env
+build
+dist
+wheels
+.wheelhouse
+.git
+.gitignore
+/tests
+.pytest_cache
+.mypy_cache
+*.egg-info
+.DS_Store
+.idea
+.vscode

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -1,0 +1,22 @@
+FROM python:3.11-slim
+LABEL maintainer="Moondream"
+WORKDIR /app
+
+# Install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir -r requirements.txt
+
+# Install moondream-station
+COPY . .
+RUN pip install --no-cache-dir -e .
+
+# Pre-configure for CPU (non-interactive)
+RUN mkdir -p /root/.moondream-station && \
+    echo '{"torch_cuda_version": "none", "torch_index_url": "https://download.pytorch.org/whl/cpu"}' \
+    > /root/.moondream-station/config.json
+
+EXPOSE 2020
+
+# Start the API server
+CMD ["moondream-station"]

--- a/README.md
+++ b/README.md
@@ -64,6 +64,18 @@ To fire up Moondream Station, execute this command in your terminal:
 $ moondream-station
 ```
 
+### Launch Moondream Station using Docker
+
+To fire up Moondream Station via Docker, execute this command in your terminal:
+```
+$ docker build -t moondream-cpu:latest -f Dockerfile.cpu .
+```
+
+Run the above docker image as container in interactive way (For CPU)
+```
+$ docker run -it -p 2020:2020 moondream-cpu:latest
+```
+
 ### Model Management
 By default, Moondream Station uses the latest model your machine supports. If you want to view or activate other Moondream models, use the following commands:
 - `models` - List available models


### PR DESCRIPTION
Hi ,

This PR introduces a Dockerised setup for Moondream Station, enabling developers to run the application in a consistent environment without requiring local Python or dependency installation. Currently this Dockerfile is for CPU based machines.

For any other enhancement feel free to reach out to me :)

Thanks & Regards,
Rohan Rustagi

CC : @jasonallen @EthanReid @Jckwind 