### PR TITLE
Pin transformers <5.0.0 to fix inference breakage

### DIFF
--- a/backends/mds_backend_0/requirements.txt
+++ b/backends/mds_backend_0/requirements.txt
@@ -1,5 +1,5 @@
 
-transformers>=4.56.1
+transformers>=4.56.1,<5.0.0
 torch>=2.7.0
 Pillow>=9.0.0
 accelerate>=1.8.1


### PR DESCRIPTION
Inference works with transformers v4 but breaks with v5. This pins the requirement to `<5.0.0` to prevent v5 from being installed.